### PR TITLE
change scope to accessModifiers for JavadocVariable in Checkstyle config

### DIFF
--- a/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
+++ b/xwiki-commons-tools/xwiki-commons-tool-verification-resources/src/main/resources/checkstyle.xml
@@ -223,7 +223,7 @@
     </module>
 
     <module name="JavadocVariable">
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
     </module>
 
     <module name="JavaNCSS"/>


### PR DESCRIPTION
This is similar to https://github.com/checkstyle/xwiki-commons/commit/05afe1a2f9b07784c3d4e136a1ea5b4bfc27d075. I'm updating the checkstyle config to be compatible with an upcoming breaking change in checkstyle. See https://github.com/checkstyle/checkstyle/pull/9277/files.

This should probably become a new branch, instead of being merged into the `checkstyle_7417` branch. But as a non-maintainer of the project I can't do this.